### PR TITLE
Refactor handleMouseMove in RectGroup component

### DIFF
--- a/frontend/src/components/Rect.tsx
+++ b/frontend/src/components/Rect.tsx
@@ -25,28 +25,32 @@ const RectGroup: Component<RectGroupProps> = (props) => {
         gRef.addEventListener("mouseleave", handleMouseUp);
     });
 
-    function handleMouseMove(event: MouseEvent) {
-        console.log('Mouse move event:', event);
-        if (isDragging()) {
-            let currentX = 0;
-            let currentY = 0;
-
-            const currentTransform = gRef.getAttribute("transform");
-            if (currentTransform) {
-                const currentTranslate = currentTransform.match(/translate\(([^,]+),([^)]+)\)/);
-                if (currentTranslate) {
+    function getTranslate() {
+        let currentX = 0;
+        let currentY = 0;
+        const currentTransform = gRef.getAttribute("transform");
+        if (currentTransform) {
+            const currentTranslate = currentTransform.match(/translate\(([^,]+),([^)]+)\)/);
+            if (currentTranslate) {
+                try {
                     currentX = parseInt(currentTranslate[1], 10);
                     currentY = parseInt(currentTranslate[2], 10);
+                } catch (e) {
+                    console.log(e);
                 }
             }
+        }
+        return {x: currentX, y: currentY}
+    }
 
-            currentX += event.offsetX - eX;
+    function handleMouseMove(event: MouseEvent) {
+        if (isDragging()) {
+            let {x, y} = getTranslate();
+            x += event.offsetX - eX;
             eX = event.offsetX;
-
-            currentY += event.offsetY - eY;
+            y += event.offsetY - eY;
             eY = event.offsetY;
-
-            let newTransform = "translate(" + currentX + ", " + currentY + ")";
+            let newTransform = "translate(" + x + ", " + y + ")";
             gRef.setAttribute("transform", newTransform);
         }
     }


### PR DESCRIPTION
The handleMouseMove function in the RectGroup component has been refactored to use the getTranslate function for retrieving the current translation values. This helps in improving code readability and reduces redundancy. The currentX and currentY variables have been renamed to x and y respectively for clarity. The updated code ensures that the element's transform attribute is correctly updated when dragging the element.